### PR TITLE
Use autoreconf instead of autogen.sh

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -38,7 +38,7 @@ See the dependencies in the `README.md`.
 
 To build from a fresh checkout:
 
-    ./autogen.sh
+    autoreconf --install
     ./configure
     make
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-aclocal && autoconf && autoheader && automake --add-missing --copy


### PR DESCRIPTION
autoreconf can take care of the work autogen.sh is currently doing.

The autoreconf(1) manpage states:

> Run  `autoconf'  (and`autoheader', `aclocal',`automake',
> `autopoint' (formerly`gettextize'), and `libtoolize' where
> appropriate) repeatedly to remake the GNU Build System files in
> specified DIRECTORIES and their subdirectories (defaulting to`.').
